### PR TITLE
Improve Redis utilities with robust URL handling and error checks

### DIFF
--- a/lib/providers/Redis/redis.ts
+++ b/lib/providers/Redis/redis.ts
@@ -1,25 +1,44 @@
 import { Redis } from 'ioredis';
 import { promisify } from 'util';
-const port = process.env.NODE_ENV === 'development' ? '6379' : '6379';
+
+const port = process.env.REDIS_PORT || '6379';
+
 const getRedisUrl = () => {
-  if (process.env.AZURE_REDIS_URL as string) {
-    return (process.env.AZURE_REDIS_URL! + port) as string;
+  const baseUrl = process.env.AZURE_REDIS_URL;
+  if (!baseUrl) {
+    const error = new Error('REDIS url is not defined');
+    console.error(error.message);
+    throw error;
   }
-  throw new Error('REDIS url is not defined');
+
+  try {
+    const url = new URL(baseUrl);
+    url.port = port;
+    return url.toString();
+  } catch (err) {
+    console.error('Invalid REDIS url', err);
+    throw err;
+  }
 };
 
 const getRedisRestUrl = () => {
-  if (process.env.UPSTASH_REDIS_REST_URL as string) {
-    return process.env.UPSTASH_REDIS_REST_URL! as string;
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  if (!url) {
+    const error = new Error('REDIS Rest url is not defined');
+    console.error(error.message);
+    throw error;
   }
-  throw new Error('REDIS Rest url is not defined');
+  return url;
 };
 
 const getRedisRestToken = () => {
-  if (process.env.UPSTASH_REDIS_REST_TOKEN as string) {
-    return process.env.UPSTASH_REDIS_REST_TOKEN! as string;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!token) {
+    const error = new Error('REDIS Rest Token is not defined');
+    console.error(error.message);
+    throw error;
   }
-  throw new Error('REDIS Rest Token is not defined');
+  return token;
 };
 
 const redis = new Redis(getRedisUrl());
@@ -31,12 +50,23 @@ const redisSet = promisify(redis.set).bind(redis);
 const redisAppend = promisify(redis.append).bind(redis);
 const redisHSet = promisify(redis.hset).bind(redis); // Add this line
 
-const fetchRedisCache = async () => {
-  const res = fetch(redisRestUrl, {
-    headers: {
-      Authorization: `Bearer ${redisRestToken}`
+const fetchRedisCache = async (): Promise<unknown | Error> => {
+  try {
+    const res = await fetch(redisRestUrl, {
+      headers: {
+        Authorization: `Bearer ${redisRestToken}`
+      }
+    });
+
+    if (!res.ok) {
+      throw new Error(`Request failed with status ${res.status}`);
     }
-  });
+
+    return await res.json();
+  } catch (error) {
+    console.error('Failed to fetch Redis cache', error);
+    return error as Error;
+  }
 };
 
 async function redisUpdate(hashName: string, field: string, value: string) {


### PR DESCRIPTION
## Summary
- build Redis URL using `URL` API and `REDIS_PORT`
- add logging for missing Redis env vars
- refactor `fetchRedisCache` to async/await with error handling

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6133151548324be4d35498c79fda0