### PR TITLE
Handle missing attendance data gracefully

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function Error({
+  error,
+  reset
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-[500px] flex flex-col items-center justify-center gap-4">
+      <h2>Something went wrong!</h2>
+      <button className="rounded-md border px-4 py-2" onClick={() => reset()}>
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import AuthComponent from '@/ui/Auth/AuthComponent';
 import AttendanceWrapper from '@/ui/Components/RealTime/AttendanceWrapper';
 import { fetchLast7Days, fetchToday, fetchYesterday } from 'lib/db';
+import Loading from './loading';
 import { auth } from './auth';
 export const dynamic = 'force-dynamic';
 
@@ -16,30 +17,39 @@ export default async function IndexPage() {
   }
 
   if (session) {
-    const [
-      { data: today, time },
-      { data: yesterday }
-      //  {data: last7days}
-    ]: any = await Promise.all([
-      fetchToday(),
-      fetchYesterday()
-      //   fetchLast7Days()
-    ]);
-    // console.log(yesterday);
-    // Kick off the last7days promise without awaiting it
-    const last7daysPromise = fetchLast7Days();
+    try {
+      const [
+        { data: today, time },
+        { data: yesterday }
+        //  {data: last7days}
+      ]: any = await Promise.all([
+        fetchToday(),
+        fetchYesterday()
+        //   fetchLast7Days()
+      ]);
 
-    const dataProps = {
-      initialData: today || [],
-      timeUpdated: time,
-      previousDayData: yesterday || [],
+      // Kick off the last7days promise without awaiting it
+      const last7daysPromise = fetchLast7Days();
 
-      // Pass the promise (or you can resolve it with suspense inside AttendanceWrapper)
-      last7days: []
-    };
-    //console.log("LAST 7 DAYS PROMISE", dataProps?.last7days);
-    if (yesterday) {
-      return <AttendanceWrapper {...dataProps} />;
+      const dataProps = {
+        initialData: today || [],
+        timeUpdated: time,
+        previousDayData: yesterday || [],
+
+        // Pass the promise (or you can resolve it with suspense inside AttendanceWrapper)
+        last7days: []
+      };
+
+      if (yesterday) {
+        return <AttendanceWrapper {...dataProps} />;
+      }
+
+      return <Loading />;
+    } catch (error) {
+      console.error('Failed to fetch attendance data', error);
+      throw error;
     }
   }
+
+  return <Loading />;
 }


### PR DESCRIPTION
## Summary
- wrap attendance fetches in try/catch
- show `<Loading />` when no previous-day data
- add global error boundary

## Testing
- `npm run make-prettier`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a6133f797c8324ab4fb2f1698a66d0