### PR TITLE
feat: add last seven days chart

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 import AuthComponent from '@/ui/Auth/AuthComponent';
 import AttendanceWrapper from '@/ui/Components/RealTime/AttendanceWrapper';
-import { fetchLast7Days, fetchToday, fetchYesterday } from 'lib/db';
+import { fetchToday, fetchYesterday } from 'lib/db';
 import Loading from './loading';
 import { auth } from './auth';
 export const dynamic = 'force-dynamic';
@@ -18,26 +18,13 @@ export default async function IndexPage() {
 
   if (session) {
     try {
-      const [
-        { data: today, time },
-        { data: yesterday }
-        //  {data: last7days}
-      ]: any = await Promise.all([
-        fetchToday(),
-        fetchYesterday()
-        //   fetchLast7Days()
-      ]);
-
-      // Kick off the last7days promise without awaiting it
-      const last7daysPromise = fetchLast7Days();
+      const [{ data: today, time }, { data: yesterday }]: any =
+        await Promise.all([fetchToday(), fetchYesterday()]);
 
       const dataProps = {
         initialData: today || [],
         timeUpdated: time,
-        previousDayData: yesterday || [],
-
-        // Pass the promise (or you can resolve it with suspense inside AttendanceWrapper)
-        last7days: []
+        previousDayData: yesterday || []
       };
 
       if (yesterday) {

--- a/ui/Components/RealTime/AttendanceWrapper.tsx
+++ b/ui/Components/RealTime/AttendanceWrapper.tsx
@@ -22,17 +22,16 @@ import Search from '../Search';
 import { AttendanceTable } from './AttendanceTable';
 import { getTableData } from './actions';
 import { useRealTimeStore } from './store';
+import LastSevenDays from './LastSevenDays';
 
 const AttendanceWrapper = ({
   initialData,
   previousDayData,
-  timeUpdated,
-  last7days
+  timeUpdated
 }: {
   initialData: AttendanceRecord[];
   previousDayData: AttendanceRecord[];
   timeUpdated: string;
-  last7days: AttendanceRecord[] | undefined;
 }) => {
   const {
     setLoading,
@@ -69,7 +68,7 @@ const AttendanceWrapper = ({
     }
 
     if (date === 'last7days') {
-      setData(last7days || []);
+      setData(null);
     }
     setDay(date);
     setLoading(false);
@@ -149,11 +148,10 @@ const AttendanceWrapper = ({
               <AttendanceTable records={dataToDisplay} />
             </Card>
           )}
-          {dataToDisplay && day === 'last7days' && last7days && (
+          {day === 'last7days' && (
             <Suspense>
               <Card className="mt-6 bg-white dark:bg-gray-800 ">
-                7 days update
-                {JSON.stringify(last7days)}
+                <LastSevenDays />
               </Card>
             </Suspense>
           )}

--- a/ui/Components/RealTime/LastSevenDays.tsx
+++ b/ui/Components/RealTime/LastSevenDays.tsx
@@ -1,5 +1,83 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AreaChart, Text } from '@tremor/react';
+import { AvailableChartColors } from 'lib/tremor/chartUtls';
+
+interface SevenDayData {
+  date: string;
+  Attendance: number;
+  Revenue: number;
+}
+
 function LastSevenDays() {
-  return <div>LastSevenDays</div>;
+  const [data, setData] = useState<SevenDayData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/v1/getLast7Days');
+        if (!res.ok) {
+          throw new Error('Failed to fetch data');
+        }
+        const json = await res.json();
+        const aggregated: Record<
+          string,
+          { attendance: number; revenue: number }
+        > = {};
+
+        json.forEach((record: any) => {
+          const date = record.perf_dt?.split('T')[0];
+          if (!date) return;
+          if (!aggregated[date]) {
+            aggregated[date] = { attendance: 0, revenue: 0 };
+          }
+          aggregated[date].attendance += record.attendance || 0;
+          aggregated[date].revenue += record.revenue || 0;
+        });
+
+        const formatted = Object.entries(aggregated)
+          .map(([date, values]) => ({
+            date,
+            Attendance: values.attendance,
+            Revenue: values.revenue
+          }))
+          .sort(
+            (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+          );
+
+        setData(formatted);
+        setError(null);
+      } catch (err: any) {
+        setError(err.message || 'Unknown error');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return <Text>Loading...</Text>;
+  }
+
+  if (error) {
+    return <Text className="text-red-500">{error}</Text>;
+  }
+
+  return (
+    <AreaChart
+      className="h-80"
+      data={data}
+      index="date"
+      categories={['Attendance', 'Revenue']}
+      colors={[AvailableChartColors[0], AvailableChartColors[1]]}
+      valueFormatter={(value: number) => value.toString()}
+    />
+  );
 }
 
 export default LastSevenDays;


### PR DESCRIPTION
## Summary
- add LastSevenDays component to fetch and chart attendance and revenue
- show 7-day view in AttendanceWrapper and drop server-side last7days fetch
- update page to pass only today and yesterday data

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7496ee8b083249b83e9f9a1aa557b